### PR TITLE
Helper for working with FileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,37 @@ This table stores data in XX.
 
 ## Hive Parquet vs Delta Lake tables
 
+## Working with Hadoop File System from Python
+
+`Eren` also provides a top level interface for working with any implementation of HadoopFileSystem (ibcluding S3, HDFS/DBFS and Local File System).
+
+```python
+from eren import fs
+
+# spark: SparkSession
+
+hdfs = fs.HadoopFileSystem(spark, "hdfs:///data") # returns an instance for access to HDFS
+s3fs = fs.HadoopFileSystem(spark, "s3a:///bucket/prefix") # returns an instance for access to S3
+local_fs = fs.HadoopFileSystem(spark, "file:///home/my-home") # return an instance for access to LocalFS
+```
+
+### Glob Files
+
+You can list files and directories on remote file system:
+
+```python
+list_of_files = hdfs.glob("hdfs:///raw/table/**/*.csv") # list all CSV files recursively inside a folder on HDFS
+```
+
+### Read/Write UTF-8 strings
+
+You can read and write UTF-8 strings from/to remote file system. But be carefully! This method is extremely slow compared to regular `spark.read`. Do not use this for reading/writing data!
+
+```python
+import json
+
+hdfs.write_utf8("hdfs:///data/results/results.json", json.dumps({"key1": 1, "key2": 3}), mode="w")
+json.loads(hdfs.read_utf8("hdfs:///data/results/results.json"))
+```
+
 

--- a/eren/fs.py
+++ b/eren/fs.py
@@ -1,0 +1,146 @@
+import enum
+import re
+from dataclasses import dataclass
+from typing import List, Literal, Tuple
+
+from py4j.java_gateway import JavaObject
+from pyspark.sql import SparkSession
+
+_FS_PATTERN = r"(s3\w*://|hdfs://|dbfs://|file://|file:/).(.*)"
+
+
+class FS_TYPES(enum.Enum):
+    DBFS = "DBFS"
+    HDFS = "HDFS"
+    S3 = "S3"
+    LOCAL = "LOCAL"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _from_pattern(cls, pattern: str):
+        return {
+            "s3://": cls.S3,
+            "s3a://": cls.S3,
+            "dbfs://": cls.DBFS,
+            "hdfs://": cls.HDFS,
+            "file://": cls.LOCAL,
+        }.get(pattern, cls.UNKNOWN)
+
+
+@dataclass
+class HDFSFile:
+    name: str
+    path: str
+    mod_time: int
+    is_dir: bool
+    fs_type: FS_TYPES
+
+
+def _get_hdfs(
+    spark: SparkSession, pattern: str
+) -> Tuple[JavaObject, JavaObject, FS_TYPES]:
+    match = re.match(_FS_PATTERN, pattern)
+    if match is None:
+        raise ValueError(
+            f"Bad pattern or path. Got {pattern} but should be"
+            " one of `s3://`, `s3a://`, `dbfs://`, `hdfs://`, `file://`"
+        )
+
+    fs_type = FS_TYPES._from_pattern(match.groups()[0])
+
+    # Java is accessible in runtime only and it is impossible to infer types here
+    hadoop = spark.sparkContext._jvm.org.apache.hadoop  # type: ignore
+    hadoop_conf = spark._jsc.hadoopConfiguration()  # type: ignore
+    uri = hadoop.fs.Path(pattern).toUri()  # type: ignore
+    hdfs = hadoop.fs.FileSystem.get(uri, hadoop_conf)  # type: ignore
+
+    return (hadoop, hdfs, fs_type)  # type: ignore
+
+
+class HadoopFileSystem(object):
+    def __init__(self: "HadoopFileSystem", spark: SparkSession, pattern: str) -> None:
+        """Helper class for working with FileSystem.
+
+        :param spark: SparkSession object
+        :param pattern: Any pattern related to FileSystem.
+                        We should provide it to choose the right implementation of org.apache.hadoop.fs.FileSystem under the hood.
+                        Pattern here should have a form of URI-like string like `s3a:///my-bucket/my-prefix` or `file:///home/user/`.
+        """
+        hadoop, hdfs, fs_type = _get_hdfs(spark, pattern)
+        self._hdfs = hdfs
+        self._fs_type = fs_type
+        self._hadoop = hadoop
+        self._jvm = spark.sparkContext._jvm
+
+    def write_utf8(
+        self: "HadoopFileSystem", path: str, data: str, mode: Literal["a", "w"]
+    ) -> None:
+        """Write a given string in UTF-16BE to the given path.
+        Do not use this method to write the data!
+        It is fantastically slow compared to `spark.write`.
+
+        :param path: Path of file
+        :param data: String to write
+        :param mode: Mode. `w` means overwrite but `a` means append.
+        """
+        if mode == "w":
+            # org.apache.hadoop.fs.FileSystem.create(Path f, boolean overwrite)
+            output_stream = self._hdfs.create(self._hadoop.fs.Path(path), True)  # type: ignore
+        elif mode == "a":
+            # org.apache.hadoop.fs.FileSystem.append(Path f)
+            output_stream = self._hdfs.append(self._hadoop.fs.Path(path))  # type: ignore
+
+        # org.apache.hadoop.fs.FSDataOutputStream
+        try:
+            for b in data.encode("utf-8"):
+                output_stream.write(b)
+            output_stream.flush()
+            output_stream.close()
+        except Exception as e:
+            output_stream.close()
+            raise e
+
+    def read_utf8(self: "HadoopFileSystem", path: str) -> str:
+        """Read string from given path.
+        Do not use this method to read the data!
+        It is fantastically slow compared to `spark.read`.
+
+        :param path: Path of file
+        :return: Decoded from UTF-8 string
+        :rtype: str
+        """
+        res = []
+        # org.apache.hadoop.fs.FileSystem.open
+        in_stream = self._hdfs.open(self._hadoop.fs.Path(path))  # type: ignore
+
+        # open returns us org.apache.hadoop.fs.FSDataInputStream
+        try:
+            while True:
+                if in_stream.available() > 0:
+                    res.append(in_stream.readByte())
+                else:
+                    in_stream.close()
+                    break
+        except Exception as e:
+            in_stream.close()
+            raise e
+
+        return bytes(res).decode("utf-8")
+
+    def glob(self, pattern: str) -> List[HDFSFile]:
+        statuses = self._hdfs.globStatus(self._hadoop.fs.Path(pattern))
+
+        res = []
+        for file_status in statuses:
+            # org.apache.hadoop.fs.FileStatus
+            res.append(
+                HDFSFile(
+                    name=file_status.getPath().getName(),
+                    path=file_status.getPath().toString(),
+                    mod_time=file_status.getModificationTime(),
+                    is_dir=file_status.isDirectory(),
+                    fs_type=self._fs_type,
+                )
+            )
+
+        return res

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,0 +1,60 @@
+import os
+
+from delta import configure_spark_with_delta_pip
+from pyspark.sql import SparkSession
+
+from eren import fs
+
+builder = (
+    SparkSession.builder.appName("MyApp")
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+    .config(
+        "spark.sql.catalog.spark_catalog",
+        "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+    )
+    .config("spark.sql.shuffle.partitions", "2")
+)
+
+spark = configure_spark_with_delta_pip(builder).getOrCreate()
+
+
+def test_read(tmp_path):
+    with open(os.path.join(tmp_path, "test_read.txt"), "w") as f_:
+        f_.write("testing_string")
+
+    file_system = fs.HadoopFileSystem(spark, "file:///")
+    read_result = file_system.read_utf8(os.path.join(tmp_path, "test_read.txt"))
+
+    assert read_result == "testing_string"
+
+
+def test_read_multiline(tmp_path):
+    with open(os.path.join(tmp_path, "test_read_mult.txt"), "w") as f_:
+        f_.write("first_line\nsecond_line")
+
+    file_system = fs.HadoopFileSystem(spark, "file:///")
+    read_result = file_system.read_utf8(os.path.join(tmp_path, "test_read_mult.txt"))
+    lines = read_result.split("\n")
+
+    assert len(lines) == 2
+    assert lines[0] == "first_line"
+    assert lines[1] == "second_line"
+
+
+def test_write(tmp_path):
+    file_system = fs.HadoopFileSystem(spark, "file:///")
+    file_system.write_utf8(
+        os.path.join(tmp_path, "test_write.txt"), "testing_string", "w"
+    )
+
+    with open(os.path.join(tmp_path, "test_write.txt"), "r") as f_:
+        res = f_.read()
+
+    assert res == "testing_string"
+
+
+def test_glob():
+    file_system = fs.HadoopFileSystem(spark, "file:///")
+    list_of_files = file_system.glob(os.path.join(".", "*"))
+    assert len(list_of_files) > 0
+    assert [f for f in list_of_files if f.name == "tests"][0].is_dir


### PR DESCRIPTION
**Motivation of such a helper**
- read/write json/yaml configs from/to FS
- read/write python pickle from/to FS (may be implemented in the future)
- save some human-readable text files (or maybe some plots like `matplotlib`)
- with read_bytes/write_bytes implemented it will be also possible to read/write Excel files to FS
- to be able to list files in FS, get the last modified, etc. without additional dependencies except PySpark

It is some kind of alternative of Databricks `dbutils`. @MrPowers we discussed this topic [in Quinn repo](https://github.com/MrPowers/quinn/issues/77) and you told me that this repository is a better place for such a functionality. By default PySpark does not provide such a functionality and the only possible options are:

- To use `py4j` that requires a good understanding of Java (and a skill to write code without auto-complete)
- To use different libraries (`boto3` for S3, `pyarrow` for HDFS, etc.)

But both ways are not so good for me that's why I want to see such a helper in some lightweight open source library (like this one).

Currently implemented:
- read_utf8
- write_utf8
- glob

The reason of such a class is to help people to read and write some config files
from Distributed FS (HDFS, DBFS, S3) with one unified interface. Under the hood
it uses `py4j` and `org.apache.hadoop.fs.FileSystem.get(uri, config)` to choose
right implementation of `FileSystem` (possible options are S3, Hdfs, Local FS
and maybe other).

Additionaly:
+ test (but for Local FS only ... but there is no difference for hadoop)

 On branch feature-hadoop-fs
 Changes to be committed:
	new file:   eren/fs.py
	new file:   tests/test_fs.py\

P.S. @MrPowers if you are OK in generally I can add some additional methods like `read_bytes`, `write_bytes` and maybe something else.
P.P.S. By default Java use UTF-16BE or MUTF-8 and both are almost unreadable from Python side. That's the reason why I implemented utf-8 reader-writer.